### PR TITLE
Make the landmark manager an attr dict

### DIFF
--- a/menpo/landmark/test/landmark_test.py
+++ b/menpo/landmark/test/landmark_test.py
@@ -118,12 +118,12 @@ def test_LandmarkManager_group_order():
     man = LandmarkManager()
     man['test_set'] = pcloud.copy()
     man['abc'] = pcloud.copy()
-    man['def'] = pcloud.copy()
-    assert_equal(list(man._landmark_groups.keys()), ['test_set', 'abc', 'def'])
+    man['efd'] = pcloud.copy()
+    assert_equal(list(man._landmark_groups.keys()), ['test_set', 'abc', 'efd'])
     # check that after deleting and inserting the order will remain the same.
     del man['test_set']
     man['tt'] = pcloud.copy()
-    assert_equal(list(man._landmark_groups.keys()), ['abc', 'def', 'tt'])
+    assert_equal(list(man._landmark_groups.keys()), ['abc', 'efd', 'tt'])
 
 
 def test_LandmarkManager_in():


### PR DESCRIPTION
> This is a special kind of mutable mapping that exposes it's
> keys as attributes. Uses the correct overriding of
> `__getattr__` and `__setattr__` in order to not override the default
> behaviour of the attributes actually on the class (inspired
> by Bunch and used under the MIT license:
> https://github.com/dsc/bunch/blob/master/LICENSE.txt).
> 
> This also makes a stronger enforcement of ASCII style string
> identifiers only for Python 2 and Unicode identifiers for
> Python 3.

An example usage is:

```python
import menpo.io as mio

lena = mio.import_builtin_asset.lenna_png()
# Access the landmarks
lena.landmarks.LJSON
# And getitem style access style works
lena.landmarks['LJSON']
# And setting works sensibly too
lena.landmarks.new_key = lena.landmarks.LJSON
lena.landmarks['another_key'] = lena.landmarks.LJSON
# And blocks bad keys
lena.landmarks['3'] = lena.landmarks.LJSON  # Fails due to invalid Python identifier
```

@jabooth @nontas @grigorisg9gr What do you think? Obviously requires https://github.com/menpo/menpo/pull/675 first